### PR TITLE
deepspeech revision changed from 0.7.0a0 to 0.7.0a1

### DIFF
--- a/DeepSpeech/Dockerfile.train
+++ b/DeepSpeech/Dockerfile.train
@@ -1,8 +1,8 @@
 FROM nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
 
 ARG ds_repo=mozilla/DeepSpeech
-ARG ds_branch=92d8bad7c113885690867a6128a7728325f540f3
-ARG ds_sha1=92d8bad7c113885690867a6128a7728325f540f3
+ARG ds_branch=60cbe3b201500b3ba74556929e04094ae0186674
+ARG ds_sha1=60cbe3b201500b3ba74556929e04094ae0186674
 ARG kenlm_repo=kpu/kenlm
 ARG kenlm_branch=2ad7cb56924cd3c6811c604973f592cb5ef604eb
 


### PR DESCRIPTION
FIXES: DeepSpeech version (0.7.0-alpha.0) requires CTC decoder to expose version. Please upgrade the ds_ctcdecoder package to version 0.7.0-alpha.0