### PR TITLE
Fix dead links

### DIFF
--- a/DeepSpeech/README.md
+++ b/DeepSpeech/README.md
@@ -66,10 +66,10 @@ C'est un processus en deux grosses étapes :
 
 ### Utiliser DeepSpeech pour vos projets web
 
-- [C#](https://github.com/mozilla/DeepSpeech/tree/master/examples/net_framework)
-- [NodeJS](https://github.com/mozilla/DeepSpeech/tree/master/examples/nodejs_wav)
-- [Streaming NodeJS](https://github.com/mozilla/DeepSpeech/tree/master/examples/ffmpeg_vad_streaming)
-- [transcription (streaming) Python](https://github.com/mozilla/DeepSpeech/tree/master/examples/vad_transcriber)
+- [C#](https://github.com/mozilla/DeepSpeech-examples/tree/master/net_framework)
+- [NodeJS](https://github.com/mozilla/DeepSpeech-examples/tree/master/nodejs_wav)
+- [Streaming NodeJS](https://github.com/mozilla/DeepSpeech-examples/tree/master/ffmpeg_vad_streaming)
+- [transcription (streaming) Python](https://github.com/mozilla/DeepSpeech-examples/tree/master/vad_transcriber)
 
 # Projets disponibles
 


### PR DESCRIPTION
DeepSpeech examples were moved to a separate repository.

New location: https://github.com/mozilla/DeepSpeech-examples